### PR TITLE
only force update if mounted

### DIFF
--- a/packages/reactive-react/src/useReactive.ts
+++ b/packages/reactive-react/src/useReactive.ts
@@ -43,15 +43,15 @@ export function useReactives<T extends any[]>(stateObjects: T, deps?: React.Depe
   }
 
   useEffect(() => {
+    mounted.current = true;
     return () => {
+      mounted.current = false;
       observer.current.removeObservers();
     };
   }, []);
 
   return useMemo(() => {
-    mounted.current = true;
     return stateObjects.map((stateObject) => {
-      mounted.current = false;
       return reactive(stateObject, observer.current);
     });
   }, deps || []) as T;

--- a/packages/reactive-react/src/useReactive.ts
+++ b/packages/reactive-react/src/useReactive.ts
@@ -5,9 +5,12 @@ export function useReactive<T>(stateObject: T, deps?: React.DependencyList): T {
   const [, forceUpdate] = useReducer((c) => c + 1, 0);
 
   const observer = useRef<Observer>();
+  const mounted = useRef(false);
   if (!observer.current) {
     observer.current = new Observer(() => {
-      forceUpdate();
+      if (mounted.current) {
+        forceUpdate();
+      }
     });
   }
 
@@ -17,7 +20,9 @@ export function useReactive<T>(stateObject: T, deps?: React.DependencyList): T {
   }, deps || []);
 
   useEffect(() => {
+    mounted.current = true;
     return () => {
+      mounted.current = false;
       observer.current.removeObservers();
     };
   }, []);
@@ -28,9 +33,12 @@ export function useReactives<T extends any[]>(stateObjects: T, deps?: React.Depe
   const [, forceUpdate] = useReducer((c) => c + 1, 0);
 
   const observer = useRef<Observer>();
+  const mounted = useRef(false);
   if (!observer.current) {
     observer.current = new Observer(() => {
-      forceUpdate();
+      if (mounted.current) {
+        forceUpdate();
+      }
     });
   }
 
@@ -41,7 +49,9 @@ export function useReactives<T extends any[]>(stateObjects: T, deps?: React.Depe
   }, []);
 
   return useMemo(() => {
+    mounted.current = true;
     return stateObjects.map((stateObject) => {
+      mounted.current = false;
       return reactive(stateObject, observer.current);
     });
   }, deps || []) as T;


### PR DESCRIPTION
In React's strict mode, each element is rendered twice, the first time to run strict mode's checks. It turns out that this first run through does run the useMemo part of useReactive, but does not call the useEffect. So, when a component is unmounted, the useEffect cleanup function is never run, and if a change is then observed it attempts to forceUpdate the component and throw the error 'Can't perform a React state update on an unmounted component'.

I was not able to reproduce the issue in a jest test, but the following code does when run in a browser.

```typescript
import React from 'react'
import { render } from 'react-dom'
import { reactive } from '@reactivedata/reactive'
import { useReactive } from '@reactivedata/react'

type Counter = {
  count: number
}

const counter = reactive<Counter>({
  count: 1
})

function Counter () {
  const state = useReactive(counter)
  return <div>count is {state.count}</div>
}

render(
  <React.StrictMode>
    <Counter />
  </React.StrictMode>,
  document.getElementById('root')
)

// second render unmounts the Counter
render (
  <React.StrictMode />,
  document.getElementById('root')
)

await Promise.resolve()

setTimeout(() => {
  counter.count += 1
}, 0)
```
